### PR TITLE
Fix UB in number tokenizer: use pointer arithmetic instead of derefer…

### DIFF
--- a/src/jsonata/Tokenizer.cpp
+++ b/src/jsonata/Tokenizer.cpp
@@ -372,11 +372,13 @@ std::unique_ptr<Tokenizer::Token> Tokenizer::next(bool prefix) {
     {
         static const std::regex numregex(
             "^-?(0|([1-9][0-9]*))(\\.[0-9]+)?([Ee][-+]?[0-9]+)?");
-        // Use byte offsets to get iterators into the original string without copying
-        auto byteStart = path_.cbegin() + static_cast<std::string::difference_type>(byte_offsets_[position_]);
-        auto byteEnd = path_.cend();
+        // Use byte offsets to get pointers into the original string without copying.
+        // Use pointer arithmetic on data() rather than dereferencing iterators:
+        // &*path_.cend() dereferences a past-the-end iterator
+        const char* byteStart = path_.data() + byte_offsets_[position_];
+        const char* byteEnd = path_.data() + path_.size();
         std::cmatch match;
-        if (std::regex_search(&*byteStart, &*byteEnd, match, numregex) &&
+        if (std::regex_search(byteStart, byteEnd, match, numregex) &&
             match.position() == 0) {
             std::string numStr = match.str(0);
             double num = std::stod(numStr);


### PR DESCRIPTION
…encing end iterator

## Summary

The number-literal scanner in `Tokenizer.cpp` passed `&*byteStart` and `&*byteEnd` to `std::regex_search`, where `byteEnd` is `path_.cend()`. Dereferencing a past-the-end iterator (`*path_.cend()`) is **undefined behavior**, even when only its address is taken.

Most standard libraries (libstdc++, libc++) happen to tolerate this, but MSVC's checked iterators (`_ITERATOR_DEBUG_LEVEL`) correctly reject it, causing an assertion failure / test crash on Windows MSVC 2022 builds.

## Fix

Form the regex range from `path_.data()` pointers instead of dereferencing iterators:

```cpp
const char* byteStart = path_.data() + byte_offsets_[position_];
const char* byteEnd   = path_.data() + path_.size();
std::cmatch match;
if (std::regex_search(byteStart, byteEnd, match, numregex) && ...)
```

`data() + size()` is a valid one-past-the-end **pointer** (legal to form, never dereferenced), which is exactly what `std::regex_search` expects for its `[first, last)` range. `std::cmatch` already operates on `const char*` ranges, so the surrounding match handling is unchanged. No behavioral change on conforming platforms — this only removes the UB that MSVC flags.

## Testing

- All existing generated tests pass.

Reported by @u19809 while building with MSVC 2022 on Windows.